### PR TITLE
fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,12 @@ bin/boot_zig.o: src/boot/boot.zig | bin
 #     libraries.  If the output format supports Unix style magic numbers, mark
 #     the output as "NMAGIC".
 #
+# TODO: When ubuntu-latest on github actions is updated, add this to remove nag.
 # --no-warn-rwx-segments
 #     Allow use of RWX segments.
+
 bin/kernel.elf: bin/boot_zig.o bin/boot.o bin/kernel.o bin/libhello.o bin/libfloof.a | bin
-	@ld \
-		--no-warn-rwx-segments \
+	ld \
 		--nmagic \
 		--output $@ \
 		--script linker.ld \
@@ -33,11 +34,11 @@ bin/kernel.elf: bin/boot_zig.o bin/boot.o bin/kernel.o bin/libhello.o bin/libflo
 
 # For debug symbols.
 #
+# TODO: When ubuntu-latest on github actions is updated, add this to remove nag.
 # --no-warn-rwx-segments
 #     Allow use of RWX segments.
 bin/kernel.dbg: bin/boot_zig.o bin/boot.o bin/kernel.o bin/libhello.o bin/libfloof.a | bin
-	@ld \
-		--no-warn-rwx-segments \
+	ld \
 		--output $@ \
 		--script linker.ld \
 		$^

--- a/Makefile
+++ b/Makefile
@@ -191,4 +191,5 @@ dump-format-config:
 	@clang-format --fcolor-diagnostics --Werror --verbose --style=file --dump-config
 
 clean:
+	@rm -rf zig-cache
 	@rm -rf bin

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We need a few dependencies before we can compile and run lappis.
 
 ```
 # Arch
-pacman -S nasm qemu mtools clang rustup zig
+pacman -S nasm qemu-full mtools clang rustup zig libisoburn
 ```
 
 </details>

--- a/src/boot/boot.zig
+++ b/src/boot/boot.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const multiboot2 = @cImport(@cInclude("multiboot2.h"));
 
-const MultiMupp = struct {
+const MultiMupp = extern struct {
     hdr: multiboot2.multiboot_header,
 
     // NOTE: multiboot tags must be 8 byte aligned.
@@ -20,7 +20,7 @@ export var multiboot linksection(".multiboot") = MultiMupp{
         .magic = MAGIC,
         .architecture = ARCH,
         .header_length = LENGTH,
-        .checksum = @bitCast(u32, -@bitCast(i32, (MAGIC + ARCH + LENGTH))), // gotta love bitcasts.
+        .checksum = @as(u32, @bitCast(-@as(i32, @bitCast((MAGIC + ARCH + LENGTH))))), // gotta love bitcasts.
     },
     .frame_buffer_tag = .{
         .type = multiboot2.MULTIBOOT_HEADER_TAG_FRAMEBUFFER,
@@ -41,7 +41,10 @@ export var multiboot linksection(".multiboot") = MultiMupp{
 extern fn init_long_mode() void;
 
 export fn multiboot_start() callconv(.Naked) noreturn {
-    init_long_mode();
+    //init_long_mode(); // TODO: call from Zig instead of inline asm when supported in Zig.
+    asm volatile (
+        \\ call init_long_mode
+    );
 
     while (true) {}
 }

--- a/src/boot/boot.zig
+++ b/src/boot/boot.zig
@@ -20,7 +20,7 @@ export var multiboot linksection(".multiboot") = MultiMupp{
         .magic = MAGIC,
         .architecture = ARCH,
         .header_length = LENGTH,
-        .checksum = @as(u32, @bitCast(-@as(i32, @bitCast((MAGIC + ARCH + LENGTH))))), // gotta love bitcasts.
+        .checksum = @as(u32, @bitCast(-@as(i32, @bitCast(MAGIC + ARCH + LENGTH)))), // gotta love bitcasts.
     },
     .frame_buffer_tag = .{
         .type = multiboot2.MULTIBOOT_HEADER_TAG_FRAMEBUFFER,
@@ -42,6 +42,7 @@ extern fn init_long_mode() void;
 
 export fn multiboot_start() callconv(.Naked) noreturn {
     //init_long_mode(); // TODO: call from Zig instead of inline asm when supported in Zig.
+
     asm volatile (
         \\ call init_long_mode
     );

--- a/src/kernel/rust/os.json
+++ b/src/kernel/rust/os.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/src/kernel/zig/hello.zig
+++ b/src/kernel/zig/hello.zig
@@ -6,7 +6,7 @@ export fn foo(
     asdf: usize,
 ) callconv(.C) usize {
     const buf = "Zig zag zaggazoo\n";
-    c.debug_buffer(@ptrCast([*]const u8, buf), buf.len);
+    c.debug_buffer(@ptrCast(buf), buf.len);
 
     return asdf + 1337;
 }


### PR DESCRIPTION
* use AT&T syntax for Clang inline asm to work around a regression observed in Clang 17.0.6 that was triggered by `__cpuid`
* update syntax of Zig
* allow RWX segments in ld